### PR TITLE
37849678: Remove @stylistic/eslint-plugin-js dependency from yaem

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   },
   "devDependencies": {
     "@foretagsplatsen/eslint-plugin": "^8.0.0",
-    "@stylistic/eslint-plugin-js": "2.2.0",
     "@vitest/coverage-v8": "^1.6.0",
     "@vitest/ui": "^1.6.0",
     "eslint": "^9.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -421,7 +421,7 @@
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
   integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
 
-"@stylistic/eslint-plugin-js@2.2.0", "@stylistic/eslint-plugin-js@^2.1.0":
+"@stylistic/eslint-plugin-js@^2.1.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@stylistic/eslint-plugin-js/-/eslint-plugin-js-2.2.0.tgz#87c46cf5498d1a1cd4d1c520123fcf00978dd856"
   integrity sha512-pdkNeVORubs+k7jmhHivYXggoFvw1ykAyGBQomodOYO8MhO8/IM798XVyjadC6EeTeBiXlEWYRy/4QV34hDz+A==


### PR DESCRIPTION
This dependency is already part of our eslint plugin.

https://3.basecamp.com/4201305/buckets/37849678/todos/7515132311

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/foretagsplatsen/yaem/176)
<!-- Reviewable:end -->
